### PR TITLE
Remove un needed connect and disconnect

### DIFF
--- a/src/rtt-logger.py
+++ b/src/rtt-logger.py
@@ -84,6 +84,8 @@ class RTTLogger(object):
                 return []
             if type(devices) != list:
                 raise Exception('enum_emu_snr didn\'t return a list')
+            nrf.connect_to_emu_with_snr(devices[0])
+            nrf.disconnect_from_emu()
         return list(map(str, devices))
 
     def start(self):

--- a/src/rtt-logger.py
+++ b/src/rtt-logger.py
@@ -84,8 +84,6 @@ class RTTLogger(object):
                 return []
             if type(devices) != list:
                 raise Exception('enum_emu_snr didn\'t return a list')
-            nrf.connect_to_emu_with_snr(devices[0])
-            nrf.disconnect_from_emu()
         return list(map(str, devices))
 
     def start(self):

--- a/src/rtt-logger.py
+++ b/src/rtt-logger.py
@@ -82,10 +82,8 @@ class RTTLogger(object):
             devices = nrf.enum_emu_snr()
             if not devices:
                 return []
-            nrf.connect_to_emu_without_snr()
             if type(devices) != list:
                 raise Exception('enum_emu_snr didn\'t return a list')
-            nrf.disconnect_from_emu()
         return list(map(str, devices))
 
     def start(self):


### PR DESCRIPTION
connect_without_snr() prompts the user to select a serial number and causes a pop up we dont want.
